### PR TITLE
修改支持符号链接并改进文件系统错误处理

### DIFF
--- a/crates/executors/src/executors/claude/slash_commands.rs
+++ b/crates/executors/src/executors/claude/slash_commands.rs
@@ -55,6 +55,7 @@ impl ClaudeCode {
             let commands_dir = base_path.join("commands");
             if commands_dir.exists() {
                 for entry in WalkDir::new(&commands_dir)
+                    .follow_links(true)
                     .max_depth(1)
                     .into_iter()
                     .filter_map(|e| e.ok())
@@ -80,6 +81,7 @@ impl ClaudeCode {
             let skills_dir = base_path.join("skills");
             if skills_dir.exists() {
                 for entry in WalkDir::new(&skills_dir)
+                    .follow_links(true)
                     .min_depth(2)
                     .max_depth(2)
                     .into_iter()

--- a/crates/executors/src/skill_config.rs
+++ b/crates/executors/src/skill_config.rs
@@ -128,8 +128,12 @@ async fn discover_skill_files(
         };
 
         while let Some(entry) = entries.next_entry().await? {
-            let file_type = entry.file_type().await?;
-            if !file_type.is_dir() {
+            let metadata = match fs::metadata(entry.path()).await {
+                Ok(metadata) => metadata,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(ExecutorError::Io(err)),
+            };
+            if !metadata.is_dir() {
                 continue;
             }
 

--- a/crates/services/src/services/skill_registry/discovery.rs
+++ b/crates/services/src/services/skill_registry/discovery.rs
@@ -259,8 +259,9 @@ async fn discover_global_skills(home_dir: &Path) -> HashMap<String, DiscoveredSk
         loop {
             match entries.next_entry().await {
                 Ok(Some(entry)) => {
-                    let file_type = match entry.file_type().await {
-                        Ok(file_type) => file_type,
+                    let metadata = match tokio::fs::metadata(entry.path()).await {
+                        Ok(metadata) => metadata,
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
                         Err(err) => {
                             tracing::warn!(
                                 path = %entry.path().display(),
@@ -271,7 +272,7 @@ async fn discover_global_skills(home_dir: &Path) -> HashMap<String, DiscoveredSk
                         }
                     };
 
-                    if !file_type.is_dir() {
+                    if !metadata.is_dir() {
                         continue;
                     }
 


### PR DESCRIPTION
修改支持符号链接并改进文件系统错误处理

- 在WalkDir遍历中添加follow_links(true)选项以支持符号链接
- 修改discover_skill_files函数使用fs::metadata替代file_type以更好地处理文件系统错误
- 添加对std::io::ErrorKind::NotFound错误的特殊处理，遇到此类错误时跳过而非中断
- 更新技能注册服务中的文件发现逻辑以一致地处理元数据获取和错误情况

使用中遇到下面只能发现非symlink的技能问题。
<img width="1007" height="469" alt="Image" src="https://github.com/user-attachments/assets/48448f12-c379-4813-a33e-ac66f5d3cd31" />
修改后symlink也能发现
<img width="1646" height="742" alt="Image" src="https://github.com/user-attachments/assets/141b996b-9f50-44e3-849b-8a0d9d647724" />