### PR TITLE
Recover running workflow executions on startup

### DIFF
--- a/crates/db/src/models/workflow_execution.rs
+++ b/crates/db/src/models/workflow_execution.rs
@@ -352,6 +352,14 @@ impl WorkflowExecution {
         .await
     }
 
+    pub async fn find_running(pool: &SqlitePool) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(&format!(
+            "{EXECUTION_SELECT}\nWHERE status = 'running'\nORDER BY updated_at ASC"
+        ))
+        .fetch_all(pool)
+        .await
+    }
+
     pub async fn find_non_terminal_by_session(
         pool: &SqlitePool,
         session_id: Uuid,

--- a/crates/db/src/models/workflow_step.rs
+++ b/crates/db/src/models/workflow_step.rs
@@ -215,6 +215,34 @@ impl WorkflowStep {
         .await
     }
 
+    pub async fn recover_orphaned_running(
+        pool: &SqlitePool,
+        id: Uuid,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE chat_workflow_steps
+            SET status = 'ready',
+                latest_run_id = NULL,
+                summary_text = NULL,
+                content = NULL,
+                started_at = NULL,
+                completed_at = NULL,
+                updated_at = datetime('now', 'subsec')
+            WHERE id = ?1 AND status = 'running'
+            RETURNING id, execution_id, round_id, compiled_revision_id, step_key,
+                      step_type, title, instructions, assigned_workflow_agent_session_id,
+                      status, retry_count, max_retry, round_index, display_order,
+                      latest_run_id, summary_text, content, loop_id,
+                      lead_review_required, user_review_required, revision_context,
+                      created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+    }
+
     pub async fn record_execution_result(
         pool: &SqlitePool,
         id: Uuid,

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -3,7 +3,14 @@ use std::{path::PathBuf, sync::Arc};
 use async_trait::async_trait;
 use db::{
     DBService,
-    models::{project_path::ProjectPath, repo::Repo},
+    models::{
+        project_path::ProjectPath,
+        repo::Repo,
+        workflow_agent_session::WorkflowAgentSession,
+        workflow_execution::WorkflowExecution,
+        workflow_step::WorkflowStep,
+        workflow_types::{WorkflowAgentSessionState, WorkflowExecutionStatus, WorkflowStepStatus},
+    },
 };
 use executors::{
     executors::StandardCodingAgentExecutor,
@@ -19,6 +26,7 @@ use services::services::{
     container::{ContainerError, ContainerService},
     image::ImageService,
     queued_message::QueuedMessageService,
+    workflow_orchestrator::reducer,
 };
 use tokio::sync::RwLock;
 use utils::msg_store::MsgStore;
@@ -88,6 +96,83 @@ async fn find_project_workspace_path(
     .await
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct OrphanWorkflowRecoverySummary {
+    running_executions_found: usize,
+    steps_recovered: usize,
+    agent_sessions_recovered: usize,
+    executions_paused: usize,
+}
+
+async fn recover_orphaned_workflow_executions(
+    pool: &sqlx::SqlitePool,
+) -> Result<OrphanWorkflowRecoverySummary, ContainerError> {
+    let running_executions = WorkflowExecution::find_running(pool).await?;
+    let mut summary = OrphanWorkflowRecoverySummary {
+        running_executions_found: running_executions.len(),
+        ..Default::default()
+    };
+
+    for execution in running_executions {
+        let steps = WorkflowStep::find_by_execution(pool, execution.id).await?;
+        for step in steps
+            .iter()
+            .filter(|step| step.status == WorkflowStepStatus::Running)
+        {
+            let recovered = reducer::recover_orphaned_running_step(pool, &execution, step)
+                .await
+                .map_err(|err| ContainerError::Other(anyhow::Error::new(err)))?;
+            if recovered.is_some() {
+                summary.steps_recovered += 1;
+            }
+        }
+
+        let recovered_steps = WorkflowStep::find_by_execution(pool, execution.id).await?;
+        let workflow_sessions = WorkflowAgentSession::find_by_execution(pool, execution.id).await?;
+        for workflow_session in workflow_sessions
+            .iter()
+            .filter(|session| session.state != WorkflowAgentSessionState::Expired)
+        {
+            let assigned_statuses = recovered_steps
+                .iter()
+                .filter(|step| step.assigned_workflow_agent_session_id == Some(workflow_session.id))
+                .map(|step| step.status.clone())
+                .collect::<Vec<_>>();
+            let derived_state =
+                reducer::derive_agent_session_state(&workflow_session.state, &assigned_statuses);
+            if derived_state != workflow_session.state {
+                reducer::transition_agent_session(
+                    pool,
+                    &execution,
+                    workflow_session,
+                    derived_state,
+                )
+                .await
+                .map_err(|err| ContainerError::Other(anyhow::Error::new(err)))?;
+                summary.agent_sessions_recovered += 1;
+            }
+        }
+
+        let current_execution = WorkflowExecution::find_by_id(pool, execution.id)
+            .await?
+            .unwrap_or(execution);
+        if current_execution.status == WorkflowExecutionStatus::Running {
+            reducer::transition_execution_with_context(
+                pool,
+                &current_execution,
+                WorkflowExecutionStatus::Paused,
+                current_execution.active_round_id,
+                Some("Recovered persisted running workflow after startup; no scheduler task survives process restart."),
+            )
+            .await
+            .map_err(|err| ContainerError::Other(anyhow::Error::new(err)))?;
+            summary.executions_paused += 1;
+        }
+    }
+
+    Ok(summary)
+}
+
 #[async_trait]
 impl ContainerService for LocalContainerService {
     async fn available_agent_slash_commands(
@@ -102,6 +187,20 @@ impl ContainerService for LocalContainerService {
             ExecutorConfigs::get_cached().get_coding_agent_or_default(&executor_profile_id);
         let stream = executor.available_slash_commands(&agent_workdir).await?;
         Ok(Some(stream))
+    }
+
+    async fn cleanup_orphan_executions(&self) -> Result<(), ContainerError> {
+        let summary = recover_orphaned_workflow_executions(&self.db.pool).await?;
+        if summary.running_executions_found > 0 {
+            tracing::info!(
+                running_executions_found = summary.running_executions_found,
+                steps_recovered = summary.steps_recovered,
+                agent_sessions_recovered = summary.agent_sessions_recovered,
+                executions_paused = summary.executions_paused,
+                "Recovered orphaned workflow executions during startup"
+            );
+        }
+        Ok(())
     }
 
     async fn backfill_repo_names(&self) -> Result<(), ContainerError> {
@@ -121,5 +220,216 @@ impl ContainerService for LocalContainerService {
     async fn kill_all_running_processes(&self) -> Result<(), ContainerError> {
         let _ = &self.git;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use db::models::{
+        workflow_agent_session::{CreateWorkflowAgentSession, WorkflowAgentSession},
+        workflow_event::WorkflowEvent,
+        workflow_execution::{CreateWorkflowExecution, WorkflowExecution},
+        workflow_plan::{CreateWorkflowPlan, WorkflowPlan},
+        workflow_round::{CreateWorkflowRound, WorkflowRound},
+        workflow_step::{CreateWorkflowStep, WorkflowStep},
+        workflow_types::{
+            WorkflowAgentSessionRole, WorkflowAgentSessionState, WorkflowEventType,
+            WorkflowExecutionStatus, WorkflowStepStatus, WorkflowStepType,
+            WorkflowValidationStatus,
+        },
+    };
+    use sqlx::SqlitePool;
+
+    use super::*;
+
+    async fn create_workflow_with_running_step(
+        pool: &SqlitePool,
+    ) -> (WorkflowExecution, WorkflowStep, WorkflowAgentSession) {
+        let session_id = Uuid::new_v4();
+        let plan_id = Uuid::new_v4();
+        let plan = WorkflowPlan::create(
+            pool,
+            &CreateWorkflowPlan {
+                session_id,
+                source_message_id: None,
+                created_by_session_agent_id: None,
+                title: "Startup recovery plan".to_string(),
+                summary_text: None,
+                plan_json: "{}".to_string(),
+                plan_schema_version: 1,
+                plan_hash: plan_id.to_string(),
+                validation_status: WorkflowValidationStatus::Valid,
+                validation_errors_json: None,
+            },
+            plan_id,
+        )
+        .await
+        .expect("create workflow plan");
+
+        let execution = WorkflowExecution::create(
+            pool,
+            &CreateWorkflowExecution {
+                session_id,
+                plan_id: plan.id,
+                active_revision_id: None,
+                lead_session_agent_id: None,
+                title: "Startup recovery execution".to_string(),
+            },
+            Uuid::new_v4(),
+        )
+        .await
+        .expect("create workflow execution");
+        let execution =
+            WorkflowExecution::update_status(pool, execution.id, WorkflowExecutionStatus::Running)
+                .await
+                .expect("mark execution running");
+
+        let round = WorkflowRound::create(
+            pool,
+            &CreateWorkflowRound {
+                execution_id: execution.id,
+                round_index: 1,
+                source_revision_id: None,
+            },
+            Uuid::new_v4(),
+        )
+        .await
+        .expect("create workflow round");
+
+        let workflow_session = WorkflowAgentSession::create(
+            pool,
+            &CreateWorkflowAgentSession {
+                workflow_execution_id: execution.id,
+                session_agent_id: Uuid::new_v4(),
+                role: WorkflowAgentSessionRole::Worker,
+            },
+            Uuid::new_v4(),
+        )
+        .await
+        .expect("create workflow agent session");
+        let workflow_session = WorkflowAgentSession::update_state(
+            pool,
+            workflow_session.id,
+            WorkflowAgentSessionState::Running,
+        )
+        .await
+        .expect("mark workflow agent session running");
+
+        let step = WorkflowStep::create(
+            pool,
+            &CreateWorkflowStep {
+                execution_id: execution.id,
+                round_id: round.id,
+                compiled_revision_id: None,
+                step_key: "task-1".to_string(),
+                step_type: WorkflowStepType::Task,
+                title: "Run task".to_string(),
+                instructions: "Do the work".to_string(),
+                assigned_workflow_agent_session_id: Some(workflow_session.id),
+                max_retry: 1,
+                round_index: 1,
+                display_order: 1,
+                loop_id: None,
+                lead_review_required: None,
+                user_review_required: None,
+                revision_context: None,
+            },
+            Uuid::new_v4(),
+        )
+        .await
+        .expect("create workflow step");
+        let step = WorkflowStep::update_status(pool, step.id, WorkflowStepStatus::Running)
+            .await
+            .expect("mark step running");
+        let step = WorkflowStep::record_execution_result(
+            pool,
+            step.id,
+            Uuid::new_v4(),
+            Some("partial summary".to_string()),
+            Some("partial content".to_string()),
+        )
+        .await
+        .expect("seed partial running output");
+
+        (execution, step, workflow_session)
+    }
+
+    #[tokio::test]
+    async fn startup_cleanup_recovers_orphaned_running_workflow_steps() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("create sqlite memory pool");
+        sqlx::migrate!("../db/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let (execution, step, workflow_session) = create_workflow_with_running_step(&pool).await;
+
+        let summary = recover_orphaned_workflow_executions(&pool)
+            .await
+            .expect("recover orphaned workflows");
+
+        assert_eq!(
+            summary,
+            OrphanWorkflowRecoverySummary {
+                running_executions_found: 1,
+                steps_recovered: 1,
+                agent_sessions_recovered: 1,
+                executions_paused: 1,
+            }
+        );
+
+        let recovered_execution = WorkflowExecution::find_by_id(&pool, execution.id)
+            .await
+            .expect("load execution")
+            .expect("execution exists");
+        assert_eq!(recovered_execution.status, WorkflowExecutionStatus::Paused);
+
+        let recovered_step = WorkflowStep::find_by_id(&pool, step.id)
+            .await
+            .expect("load step")
+            .expect("step exists");
+        assert_eq!(recovered_step.status, WorkflowStepStatus::Ready);
+        assert!(recovered_step.latest_run_id.is_none());
+        assert!(recovered_step.summary_text.is_none());
+        assert!(recovered_step.content.is_none());
+        assert!(recovered_step.started_at.is_none());
+        assert!(recovered_step.completed_at.is_none());
+
+        let recovered_workflow_session =
+            WorkflowAgentSession::find_by_id(&pool, workflow_session.id)
+                .await
+                .expect("load workflow agent session")
+                .expect("workflow agent session exists");
+        assert_eq!(
+            recovered_workflow_session.state,
+            WorkflowAgentSessionState::Idle
+        );
+
+        let events = WorkflowEvent::find_by_execution(&pool, execution.id)
+            .await
+            .expect("load workflow events");
+        assert!(events.iter().any(|event| {
+            event.event_type == WorkflowEventType::StepStatusChanged
+                && event.step_id == Some(step.id)
+                && event.status_before.as_deref() == Some("running")
+                && event.status_after.as_deref() == Some("ready")
+                && event
+                    .detail_json
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("startup_orphan_recovery"))
+        }));
+        assert!(events.iter().any(|event| {
+            event.event_type == WorkflowEventType::AgentSessionStateChanged
+                && event.agent_session_id == Some(workflow_session.id)
+                && event.status_before.as_deref() == Some("running")
+                && event.status_after.as_deref() == Some("idle")
+        }));
+        assert!(events.iter().any(|event| {
+            event.event_type == WorkflowEventType::ExecutionPaused
+                && event.status_before.as_deref() == Some("running")
+                && event.status_after.as_deref() == Some("paused")
+        }));
     }
 }

--- a/crates/services/src/services/workflow/orchestrator/reducer.rs
+++ b/crates/services/src/services/workflow/orchestrator/reducer.rs
@@ -601,6 +601,73 @@ pub async fn guarded_transition_step(
     })
 }
 
+pub async fn recover_orphaned_running_step(
+    pool: &SqlitePool,
+    execution: &WorkflowExecution,
+    step: &WorkflowStep,
+) -> Result<Option<TransitionResult<WorkflowStep>>, TransitionError> {
+    if step.status != WorkflowStepStatus::Running {
+        return Ok(None);
+    }
+
+    let to = WorkflowStepStatus::Ready;
+    if !validate_step_in_execution(&execution.status, &to) {
+        return Err(TransitionError::IllegalStepTransition {
+            from: format!("{:?}", step.status),
+            to: format!("{:?} (execution 状态 {:?} 下不允许)", to, execution.status),
+        });
+    }
+
+    let from_str = to_workflow_wire_value(&step.status);
+    let to_str = to_workflow_wire_value(&to);
+
+    let Some(updated) = WorkflowStep::recover_orphaned_running(pool, step.id).await? else {
+        tracing::warn!(
+            step_id = %step.id,
+            expected = ?step.status,
+            "orphaned workflow step recovery skipped: row no longer running"
+        );
+        return Ok(None);
+    };
+
+    let event = WorkflowEvent::create(
+        pool,
+        &CreateWorkflowEvent {
+            execution_id: execution.id,
+            round_id: Some(step.round_id),
+            step_id: Some(step.id),
+            agent_session_id: step.assigned_workflow_agent_session_id,
+            event_type: WorkflowEventType::StepStatusChanged,
+            status_before: Some(from_str.clone()),
+            status_after: Some(to_str.clone()),
+            detail_json: Some(
+                serde_json::json!({
+                    "step_key": step.step_key,
+                    "step_title": step.title,
+                    "recovery": "startup_orphan_recovery",
+                })
+                .to_string(),
+            ),
+        },
+        Uuid::new_v4(),
+    )
+    .await?;
+
+    tracing::info!(
+        execution_id = %execution.id,
+        step_id = %step.id,
+        step_key = %step.step_key,
+        from = %from_str,
+        to = %to_str,
+        "orphaned workflow step recovered"
+    );
+
+    Ok(Some(TransitionResult {
+        entity: updated,
+        event,
+    }))
+}
+
 /// Atomically transition an execution using compare-and-swap at the DB level.
 /// Returns `Err(StaleTransition)` if the execution's current DB status no
 /// longer matches `execution.status`.


### PR DESCRIPTION
## Summary

- Recover workflow executions that were persisted as `running` when the server starts.
- Reset orphaned `running` workflow steps back to `ready`, clear partial attempt output fields, and resynchronize assigned workflow agent sessions.
- Add a startup cleanup regression test covering execution, step, agent-session, and audit-event state.

## Root cause

Workflow step execution is claimed durably before the in-memory scheduler awaits the agent run. If the process exits after that `running` transition, no scheduler task survives restart to finish the step. The persisted execution can keep reporting active work even though there is no owner for it, and manual resume rejects executions that are still `running`.

## Why it matters

After a restart during workflow execution, users can otherwise see a workflow stuck in an active state with no way to resume it. Startup recovery now converts those orphaned persisted states into a paused, resumable workflow with the abandoned step ready to run again.

## Validation

- `cargo test -p local-deployment startup_cleanup_recovers_orphaned_running_workflow_steps`
- `cargo test -p local-deployment`
- `cargo test -p db`
- `cargo test -p services workflow_orchestrator::reducer`
- `cargo fmt --all -- --check`
- `cargo run --bin generate_types -- --check`
- `node scripts/prepare-db.js --check`
- `cargo test --workspace` passes until the unrelated worktree smoke failure noted below.

## Known unrelated local failures

- `cargo test --workspace` fails in `server` test `session_worktree_routes_cover_main_merge_conflict_and_cleanup_flows` at `crates/server/tests/worktree_integration_smoke.rs:258` with `assertion failed: base.join("session.txt").exists()`. Reproduced standalone with `cargo test -p server --test worktree_integration_smoke session_worktree_routes_cover_main_merge_conflict_and_cleanup_flows`.
- `cargo clippy --workspace --all-targets --features qa-mode -- -D warnings` currently stops in `crates/executors` on existing lints before reaching this patch's crates: `clippy::question_mark` in `codex/normalize_logs.rs`, `clippy::collapsible_if` in `opencode.rs` and `openteams_cli.rs`, and `clippy::ptr_arg` in `opencode.rs`.
