### PR TITLE
fix: recover Kimi sessions and scope MCP configs

### DIFF
--- a/crates/executors/src/executors/acp/config.rs
+++ b/crates/executors/src/executors/acp/config.rs
@@ -335,7 +335,7 @@ impl Default for AcpClientServicePolicy {
     }
 }
 
-/// How the generic ACP runtime classifies a refusal after session recovery.
+/// How the generic ACP runtime handles adapter-specific session recovery behavior.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AcpResumePolicy {
     /// Preserve the Agent's refusal as a normal turn result.
@@ -344,6 +344,9 @@ pub enum AcpResumePolicy {
     /// If recovery had to reuse the requested ID because the response omitted
     /// `sessionId`, classify a refusal as an invalid session.
     RefusalMeansInvalidSession,
+    /// If resume/load explicitly reports that the requested session is unknown,
+    /// create a replacement session so the caller can persist its new ID.
+    UnknownSessionStartsNew,
 }
 
 /// Per-run inputs for the generic ACP runtime.

--- a/crates/executors/src/executors/acp/runtime.rs
+++ b/crates/executors/src/executors/acp/runtime.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use agent_client_protocol::{
-    Agent, ConnectionTo, Lines, UntypedMessage,
+    Agent, ConnectionTo, ErrorCode, Lines, UntypedMessage,
     schema::{
         ProtocolVersion,
         v1::{
@@ -933,6 +933,14 @@ fn parse_session_start_response(
     })
 }
 
+fn is_unknown_session_error(error: &agent_client_protocol::Error) -> bool {
+    matches!(error.code, ErrorCode::ResourceNotFound)
+        || matches!(error.code, ErrorCode::InvalidParams) && {
+            let message = error.message.to_ascii_lowercase();
+            message.contains("unknown session") || message.contains("session not found")
+        }
+}
+
 fn snapshot_config_options(options: &[SessionConfigOption]) -> Vec<AcpConfigOptionSnapshot> {
     options.iter().filter_map(snapshot_config_option).collect()
 }
@@ -1093,7 +1101,7 @@ async fn run_connection(
             .data("ACP Agent does not support additionalDirectories"));
     }
 
-    let is_follow_up = existing_session.is_some();
+    let mut resumed_existing_session = false;
     let mut session_state = match existing_session {
         None => {
             send_session_start_request(
@@ -1108,7 +1116,7 @@ async fn run_connection(
         }
         Some(existing) => {
             let session_id = SessionId::new(existing);
-            if negotiated
+            let resume_result = if negotiated
                 .agent_capabilities
                 .session_capabilities
                 .resume
@@ -1120,9 +1128,9 @@ async fn run_connection(
                     ResumeSessionRequest::new(session_id.clone(), cwd)
                         .additional_directories(config.additional_directories.clone())
                         .mcp_servers(config.mcp_servers.clone()),
-                    Some(session_id),
+                    Some(session_id.clone()),
                 )
-                .await?
+                .await
             } else if negotiated.agent_capabilities.load_session {
                 send_session_start_request(
                     connection,
@@ -1130,9 +1138,9 @@ async fn run_connection(
                     LoadSessionRequest::new(session_id.clone(), cwd)
                         .additional_directories(config.additional_directories.clone())
                         .mcp_servers(config.mcp_servers.clone()),
-                    Some(session_id),
+                    Some(session_id.clone()),
                 )
-                .await?
+                .await
             } else {
                 let message =
                     "Agent advertises neither session/resume nor session/load".to_string();
@@ -1141,6 +1149,31 @@ async fn run_connection(
                     Err(BootstrapError::FollowUpNotSupported(message.clone())),
                 );
                 return Err(agent_client_protocol::Error::method_not_found().data(message));
+            };
+            match resume_result {
+                Ok(state) => {
+                    resumed_existing_session = true;
+                    state
+                }
+                Err(error)
+                    if config.resume_policy == AcpResumePolicy::UnknownSessionStartsNew
+                        && is_unknown_session_error(&error) =>
+                {
+                    tracing::warn!(
+                        requested_session_id = %session_id.0,
+                        "ACP Agent no longer knows the persisted session; starting a replacement session"
+                    );
+                    send_session_start_request(
+                        connection,
+                        "session/new",
+                        NewSessionRequest::new(cwd)
+                            .additional_directories(config.additional_directories.clone())
+                            .mcp_servers(config.mcp_servers.clone()),
+                        None,
+                    )
+                    .await?
+                }
+                Err(error) => return Err(error),
             }
         }
     };
@@ -1195,7 +1228,7 @@ async fn run_connection(
         }
     };
     if config.resume_policy == AcpResumePolicy::RefusalMeansInvalidSession
-        && is_follow_up
+        && resumed_existing_session
         && session_id_was_fallback
         && response.stop_reason == StopReason::Refusal
     {
@@ -1778,6 +1811,25 @@ mod tests {
             AcpAgentHarness::new().config.resume_policy,
             AcpResumePolicy::PreserveRefusal
         );
+
+        let harness =
+            AcpAgentHarness::new().with_resume_policy(AcpResumePolicy::UnknownSessionStartsNew);
+        assert_eq!(
+            harness.config.resume_policy,
+            AcpResumePolicy::UnknownSessionStartsNew
+        );
+    }
+
+    #[test]
+    fn unknown_session_detection_is_narrow_to_resume_lookup_errors() {
+        let unknown =
+            agent_client_protocol::Error::new(-32602, "Unknown sessionId: session_fixture");
+        let missing = agent_client_protocol::Error::resource_not_found(None);
+        let unrelated = agent_client_protocol::Error::invalid_params().data("invalid cwd");
+
+        assert!(is_unknown_session_error(&unknown));
+        assert!(is_unknown_session_error(&missing));
+        assert!(!is_unknown_session_error(&unrelated));
     }
 
     #[test]

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -836,18 +836,9 @@ fn build_codex_mcp_servers(canonical: &MemberMcpConfig) -> Result<Value, Executo
                 server.get("type").and_then(Value::as_str),
                 Some("http" | "sse")
             );
-        let allowed = if is_remote {
-            ["type", "url", "httpUrl", "headers", "enabled", "disabled"].as_slice()
-        } else {
-            ["type", "command", "args", "env", "enabled", "disabled"].as_slice()
-        };
-        if server.keys().any(|key| !allowed.contains(&key.as_str())) {
-            return Err(ExecutorError::Configuration(
-                "Codex cannot safely translate a member MCP server field".to_string(),
-            ));
-        }
-
-        let mut converted = Map::new();
+        let mut converted = server.clone();
+        converted.remove("type");
+        converted.remove("disabled");
         if is_remote {
             if server.get("type").and_then(Value::as_str) == Some("sse") {
                 return Err(ExecutorError::McpNotSupported);
@@ -866,9 +857,10 @@ fn build_codex_mcp_servers(canonical: &MemberMcpConfig) -> Result<Value, Executo
                     "Codex rejected an empty member MCP remote URL".to_string(),
                 ));
             }
+            converted.remove("httpUrl");
             converted.insert("url".to_string(), url);
-            if let Some(headers) = server.get("headers") {
-                converted.insert("http_headers".to_string(), headers.clone());
+            if let Some(headers) = converted.remove("headers") {
+                converted.insert("http_headers".to_string(), headers);
             }
         } else {
             if !matches!(
@@ -891,11 +883,6 @@ fn build_codex_mcp_servers(canonical: &MemberMcpConfig) -> Result<Value, Executo
                 ));
             }
             converted.insert("command".to_string(), command);
-            for field in ["args", "env"] {
-                if let Some(value) = server.get(field) {
-                    converted.insert(field.to_string(), value.clone());
-                }
-            }
         }
         if let Some(enabled) = effective_mcp_enabled(server) {
             converted.insert("enabled".to_string(), Value::Bool(enabled));
@@ -1254,17 +1241,46 @@ mod tests {
     }
 
     #[test]
-    fn codex_mcp_translation_rejects_unknown_fields_without_echoing_secrets() {
-        let secret = "unknown-field-secret";
+    fn codex_mcp_translation_preserves_extension_fields() {
         let canonical: MemberMcpConfig = serde_json::from_value(json!({
             "mcpServers": {
-                "local": {"command": "/bin/echo", "vendorSecret": secret}
+                "computer-use": {
+                    "command": "/bin/echo",
+                    "cwd": ".",
+                    "enabled": false
+                },
+                "node_repl": {
+                    "command": "/bin/echo",
+                    "startup_timeout_sec": 120,
+                    "future_option": {"nested": true}
+                },
+                "remote": {
+                    "url": "https://example.test/mcp",
+                    "headers": {"X-Mode": "test"},
+                    "future_remote_option": "preserved",
+                    "disabled": false
+                }
             }
         }))
         .expect("deserialize config");
 
-        let error = build_codex_mcp_servers(&canonical).expect_err("unknown field must fail");
-        assert!(!error.to_string().contains(secret));
+        let converted = build_codex_mcp_servers(&canonical).expect("translate MCP config");
+
+        assert_eq!(converted["computer-use"]["cwd"], json!("."));
+        assert_eq!(converted["computer-use"]["enabled"], json!(false));
+        assert_eq!(converted["node_repl"]["startup_timeout_sec"], json!(120));
+        assert_eq!(
+            converted["node_repl"]["future_option"],
+            json!({"nested": true})
+        );
+        assert_eq!(
+            converted["remote"]["future_remote_option"],
+            json!("preserved")
+        );
+        assert_eq!(converted["remote"]["http_headers"]["X-Mode"], "test");
+        assert_eq!(converted["remote"]["enabled"], json!(true));
+        assert!(converted["remote"].get("headers").is_none());
+        assert!(converted["remote"].get("disabled").is_none());
     }
 
     #[test]

--- a/crates/executors/src/executors/kimi.rs
+++ b/crates/executors/src/executors/kimi.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::BTreeSet,
+    fs::{self, DirBuilder, OpenOptions},
+    io::Write,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -14,7 +16,7 @@ use workspace_utils::msg_store::MsgStore;
 use super::acp::{
     AcpAccessMode, AcpAgentHarness, AcpApprovalMode, AcpApprovalPolicy, AcpAuthSelection,
     AcpCapabilityProbe, AcpClientServicePolicy, AcpConfigChoice, AcpConfigOptionKind,
-    AcpConfigOptionSnapshot, AcpConfigSource, AcpExecutionOptions,
+    AcpConfigOptionSnapshot, AcpConfigSource, AcpExecutionOptions, AcpResumePolicy,
     mcp::{
         AcpMcpPolicy, load_prepared_acp_mcp_config, pin_mcp_run_environment,
         prepare_acp_mcp_for_run,
@@ -32,7 +34,7 @@ use crate::{
         utils::{json_has_nonempty_string, read_json_file},
     },
     mcp_config::MemberMcpConfig,
-    mcp_run::{McpRunContext, PreparedMcpRun, PrivateMcpRunDirectory},
+    mcp_run::{McpRunContext, PreparedMcpRun},
     model_discovery::{
         discover_model_map_from_cli_command, model_ids_from_model_map_json, read_config_value,
     },
@@ -110,6 +112,7 @@ impl KimiCode {
         let full_access = options.access_mode.unwrap_or_default() == AcpAccessMode::FullAccess;
         let mut harness = AcpAgentHarness::new()
             .with_approval_policy(approval_policy)
+            .with_resume_policy(AcpResumePolicy::UnknownSessionStartsNew)
             .with_required_session_mode("mode", "default")
             .with_additional_directories(additional_directories)
             .with_client_services(AcpClientServicePolicy {
@@ -247,16 +250,176 @@ impl KimiCode {
 async fn copy_optional_kimi_run_file(
     source_home: Option<&Path>,
     relative_path: &Path,
-    directory: &PrivateMcpRunDirectory,
+    run_home: &Path,
 ) -> Result<(), ExecutorError> {
-    let Some(source_home) = source_home else {
-        return Ok(());
+    let contents = match source_home {
+        Some(source_home) => tokio::fs::read(source_home.join(relative_path)).await,
+        None => Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
     };
-    match tokio::fs::read(source_home.join(relative_path)).await {
+    match contents {
         Ok(contents) => {
-            directory.write_file(relative_path, &contents)?;
+            let target = run_home.join(relative_path);
+            replace_private_kimi_run_file(&target, &contents)?;
             Ok(())
         }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            remove_optional_kimi_run_file(&run_home.join(relative_path))?;
+            Ok(())
+        }
+        Err(error) => Err(ExecutorError::Io(error)),
+    }
+}
+
+fn kimi_credential_expiry(contents: &[u8]) -> Option<f64> {
+    serde_json::from_slice::<serde_json::Value>(contents)
+        .ok()?
+        .get("expires_at")?
+        .as_f64()
+}
+
+/// Keep OAuth refreshes written by Kimi in the stable session home. The
+/// canonical login wins again when it has a later expiry (for example after an
+/// explicit `kimi login`), while an older canonical token must not overwrite a
+/// token that Kimi refreshed during the previous run.
+async fn sync_kimi_run_credentials(
+    source_home: Option<&Path>,
+    run_home: &Path,
+) -> Result<(), ExecutorError> {
+    let relative_path = Path::new("credentials/kimi-code.json");
+    let target = run_home.join(relative_path);
+    let Some(source) = source_home.map(|home| home.join(relative_path)) else {
+        remove_optional_kimi_run_file(&target)?;
+        return Ok(());
+    };
+    if source == target {
+        return match fs::symlink_metadata(&target) {
+            Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => Ok(()),
+            Ok(_) => Err(ExecutorError::Configuration(
+                "Kimi credentials path is not a regular file".to_string(),
+            )),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(ExecutorError::Io(error)),
+        };
+    }
+
+    let source_contents = match tokio::fs::read(&source).await {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            remove_optional_kimi_run_file(&target)?;
+            return Ok(());
+        }
+        Err(error) => return Err(ExecutorError::Io(error)),
+    };
+    let keep_refreshed_target = match fs::symlink_metadata(&target) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            let target_contents = tokio::fs::read(&target).await.map_err(ExecutorError::Io)?;
+            match (
+                kimi_credential_expiry(&target_contents),
+                kimi_credential_expiry(&source_contents),
+            ) {
+                (Some(target_expiry), Some(source_expiry)) => target_expiry >= source_expiry,
+                _ => false,
+            }
+        }
+        Ok(_) => {
+            return Err(ExecutorError::Configuration(
+                "Kimi credentials path is not a regular file".to_string(),
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(ExecutorError::Io(error)),
+    };
+    if !keep_refreshed_target {
+        replace_private_kimi_run_file(&target, &source_contents)?;
+    }
+    Ok(())
+}
+
+/// Kimi persists each session index entry with an absolute path below
+/// `KIMI_CODE_HOME`, so this home must stay stable across follow-up runs.
+fn kimi_session_home(context: &McpRunContext) -> Result<PathBuf, ExecutorError> {
+    let workspace = fs::canonicalize(context.current_dir()).map_err(ExecutorError::Io)?;
+    let runtime_root = context.current_dir().join(".openteams");
+    create_private_kimi_directory(&runtime_root)?;
+    let runtime_root = fs::canonicalize(&runtime_root).map_err(ExecutorError::Io)?;
+    if !runtime_root.starts_with(&workspace) {
+        return Err(ExecutorError::Configuration(
+            "Kimi session state directory escapes the workspace".to_string(),
+        ));
+    }
+
+    let executor_state_root = runtime_root.join("executor-state");
+    create_private_kimi_directory(&executor_state_root)?;
+    let state_root = executor_state_root.join("kimi-code");
+    create_private_kimi_directory(&state_root)?;
+
+    let session_home = state_root.join(context.session_agent_id().to_string());
+    create_private_kimi_directory(&session_home)?;
+    Ok(session_home)
+}
+
+fn create_private_kimi_directory(path: &Path) -> Result<(), ExecutorError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => return Ok(()),
+        Ok(_) => {
+            return Err(ExecutorError::Configuration(
+                "Kimi session state path is not a directory".to_string(),
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(ExecutorError::Io(error)),
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(ExecutorError::Io)?;
+    }
+    let mut builder = DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    match builder.create(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path).map_err(ExecutorError::Io)?;
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                Ok(())
+            } else {
+                Err(ExecutorError::Configuration(
+                    "Kimi session state path is not a directory".to_string(),
+                ))
+            }
+        }
+        Err(error) => Err(ExecutorError::Io(error)),
+    }
+}
+
+fn replace_private_kimi_run_file(path: &Path, contents: &[u8]) -> Result<(), ExecutorError> {
+    remove_optional_kimi_run_file(path)?;
+    if let Some(parent) = path.parent() {
+        create_private_kimi_directory(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).map_err(ExecutorError::Io)?;
+    file.write_all(contents).map_err(ExecutorError::Io)?;
+    file.sync_all().map_err(ExecutorError::Io)
+}
+
+fn remove_optional_kimi_run_file(path: &Path) -> Result<(), ExecutorError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() || metadata.file_type().is_symlink() => {
+            fs::remove_file(path).map_err(ExecutorError::Io)
+        }
+        Ok(_) => Err(ExecutorError::Configuration(
+            "Kimi transient run path is not a file".to_string(),
+        )),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(ExecutorError::Io(error)),
     }
@@ -274,23 +437,23 @@ impl StandardCodingAgentExecutor for KimiCode {
         let source_home = kimi_code_home(Some(&source_env));
         let prepared =
             prepare_acp_mcp_for_run(canonical, context, env, &mut self.cmd, "kimi-acp-mcp")?;
-        let directory = PrivateMcpRunDirectory::create(context, "kimi-code-home")?;
-        copy_optional_kimi_run_file(source_home.as_deref(), Path::new("config.toml"), &directory)
+        let run_home = kimi_session_home(context)?;
+        let vendor_mcp_path = run_home.join("mcp.json");
+        let transient_cleanup = crate::executors::ExecutorRunCleanup::new(vec![
+            run_home.join("config.toml"),
+            vendor_mcp_path.clone(),
+        ]);
+        copy_optional_kimi_run_file(source_home.as_deref(), Path::new("config.toml"), &run_home)
             .await?;
-        copy_optional_kimi_run_file(
-            source_home.as_deref(),
-            Path::new("credentials/kimi-code.json"),
-            &directory,
-        )
-        .await?;
-        directory.write_file(
-            "mcp.json",
+        replace_private_kimi_run_file(
+            &vendor_mcp_path,
             &serde_json::to_vec_pretty(&serde_json::json!({"mcpServers": {}}))?,
         )?;
-        let run_home = directory.path().to_string_lossy().into_owned();
+        sync_kimi_run_credentials(source_home.as_deref(), &run_home).await?;
+        let run_home = run_home.to_string_lossy().into_owned();
         pin_mcp_run_environment(env, &mut self.cmd, Self::CODE_HOME_ENV, run_home.clone());
         pin_mcp_run_environment(env, &mut self.cmd, Self::SHARE_DIR_ENV, run_home);
-        Ok(prepared.with_cleanup(directory.into_cleanup()))
+        Ok(prepared.with_cleanup(transient_cleanup))
     }
 
     fn overlay_acp_execution_options(&mut self, higher_priority: &AcpExecutionOptions) {
@@ -616,8 +779,11 @@ mod tests {
     use crate::env::RepoContext;
 
     fn run_context(workspace: &Path) -> McpRunContext {
-        McpRunContext::new(workspace, uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
-            .expect("run context")
+        run_context_for(workspace, uuid::Uuid::new_v4())
+    }
+
+    fn run_context_for(workspace: &Path, session_agent_id: uuid::Uuid) -> McpRunContext {
+        McpRunContext::new(workspace, session_agent_id, uuid::Uuid::new_v4()).expect("run context")
     }
 
     fn kimi() -> KimiCode {
@@ -771,7 +937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_preparation_builds_private_home_preserves_auth_and_clears_vendor_mcp() {
+    async fn public_preparation_keeps_refreshed_credentials_with_session_state() {
         let workspace = tempfile::tempdir().expect("workspace");
         let source_home = workspace.path().join("source-kimi-home");
         tokio::fs::create_dir_all(source_home.join("credentials"))
@@ -788,7 +954,7 @@ mod tests {
         .expect("Kimi config");
         tokio::fs::write(
             &source_credentials_path,
-            r#"{"access_token":"fixture-login-token"}"#,
+            r#"{"access_token":"fixture-login-token","refresh_token":"fixture-refresh-token","expires_at":10}"#,
         )
         .await
         .expect("Kimi credentials");
@@ -830,8 +996,13 @@ mod tests {
             source_home.to_string_lossy().into_owned(),
         );
 
+        let session_agent_id = uuid::Uuid::new_v4();
         let prepared = executor
-            .prepare_mcp_for_run(&canonical, &run_context(workspace.path()), &mut env)
+            .prepare_mcp_for_run(
+                &canonical,
+                &run_context_for(workspace.path(), session_agent_id),
+                &mut env,
+            )
             .await
             .expect("Kimi MCP preparation");
         let run_home = PathBuf::from(env.get(KimiCode::CODE_HOME_ENV).expect("run Kimi home"));
@@ -897,8 +1068,37 @@ mod tests {
         assert!(executor.is_authenticated(&env));
         assert_eq!(effective.server_names(), ["member-only".to_string()].into());
 
+        let persisted_session = run_home
+            .join("sessions")
+            .join("wd_fixture")
+            .join("session_fixture")
+            .join("state.json");
+        tokio::fs::create_dir_all(persisted_session.parent().expect("session directory"))
+            .await
+            .expect("create persisted Kimi session directory");
+        tokio::fs::write(&persisted_session, b"{}")
+            .await
+            .expect("write persisted Kimi session state");
+        let refreshed_credentials =
+            br#"{"access_token":"refreshed-token","refresh_token":"rotated-token","expires_at":20}"#;
+        tokio::fs::write(
+            run_home.join("credentials/kimi-code.json"),
+            refreshed_credentials,
+        )
+        .await
+        .expect("simulate Kimi OAuth refresh");
+
         drop(prepared.into_cleanup());
-        assert!(!run_home.exists());
+        assert!(run_home.exists());
+        assert!(persisted_session.is_file());
+        assert!(!run_home.join("config.toml").exists());
+        assert_eq!(
+            tokio::fs::read(run_home.join("credentials/kimi-code.json"))
+                .await
+                .expect("refreshed credentials survive cleanup"),
+            refreshed_credentials
+        );
+        assert!(!run_home.join("mcp.json").exists());
         assert!(!snapshot_path.exists());
         assert_eq!(
             tokio::fs::read(&source_config_path)
@@ -918,6 +1118,45 @@ mod tests {
                 .expect("read source Kimi MCP after cleanup"),
             original_mcp
         );
+
+        let mut next_env = ExecutionEnv::new(
+            RepoContext::new(workspace.path().to_path_buf(), Vec::new()),
+            false,
+            String::new(),
+        );
+        next_env.insert(
+            KimiCode::CODE_HOME_ENV,
+            source_home.to_string_lossy().into_owned(),
+        );
+        let mut next_executor = kimi();
+        next_executor.acp_mcp_policy = AcpMcpPolicy {
+            allowed_server_names: Some(Default::default()),
+            disabled_server_names: Default::default(),
+        };
+        let next_prepared = next_executor
+            .prepare_mcp_for_run(
+                &canonical,
+                &run_context_for(workspace.path(), session_agent_id),
+                &mut next_env,
+            )
+            .await
+            .expect("second Kimi MCP preparation");
+        let next_home = PathBuf::from(
+            next_env
+                .get(KimiCode::CODE_HOME_ENV)
+                .expect("second run Kimi home"),
+        );
+        assert_eq!(next_home, run_home);
+        assert!(persisted_session.is_file());
+        assert_eq!(
+            tokio::fs::read(next_home.join("credentials/kimi-code.json"))
+                .await
+                .expect("second run credentials"),
+            refreshed_credentials,
+            "an older source token must not replace Kimi's refreshed token"
+        );
+        drop(next_prepared.into_cleanup());
+        assert!(next_home.join("credentials/kimi-code.json").is_file());
     }
 
     #[tokio::test]
@@ -1028,7 +1267,15 @@ mod tests {
         );
 
         drop(prepared.into_cleanup());
-        assert!(!run_home.exists());
+        assert!(run_home.exists());
+        assert!(!run_home.join("config.toml").exists());
+        assert_eq!(
+            tokio::fs::read(run_home.join("credentials/kimi-code.json"))
+                .await
+                .expect("persistent Kimi credentials"),
+            original_credentials
+        );
+        assert!(!run_home.join("mcp.json").exists());
         assert_eq!(
             tokio::fs::read(&source_config_path)
                 .await
@@ -1047,6 +1294,51 @@ mod tests {
                 .expect("read source Kimi MCP after cleanup"),
             original_mcp
         );
+    }
+
+    #[tokio::test]
+    async fn failed_stable_home_preparation_does_not_seed_credentials() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let source_home = workspace.path().join("source-kimi-home");
+        tokio::fs::create_dir_all(source_home.join("credentials"))
+            .await
+            .expect("source credentials directory");
+        tokio::fs::write(
+            source_home.join("config.toml"),
+            "default_model = \"fixture\"",
+        )
+        .await
+        .expect("source config");
+        tokio::fs::write(
+            source_home.join("credentials/kimi-code.json"),
+            r#"{"access_token":"fixture-login-token"}"#,
+        )
+        .await
+        .expect("source credentials");
+
+        let context = run_context(workspace.path());
+        let run_home = kimi_session_home(&context).expect("stable Kimi home");
+        tokio::fs::create_dir(run_home.join("mcp.json"))
+            .await
+            .expect("blocking vendor MCP directory");
+        let mut env = ExecutionEnv::new(
+            RepoContext::new(workspace.path().to_path_buf(), Vec::new()),
+            false,
+            String::new(),
+        );
+        env.insert(
+            KimiCode::CODE_HOME_ENV,
+            source_home.to_string_lossy().into_owned(),
+        );
+
+        let error = kimi()
+            .prepare_mcp_for_run(&MemberMcpConfig::default(), &context, &mut env)
+            .await
+            .expect_err("non-file MCP target must fail closed");
+
+        assert!(error.to_string().contains("not a file"));
+        assert!(!run_home.join("config.toml").exists());
+        assert!(!run_home.join("credentials/kimi-code.json").exists());
     }
 
     #[tokio::test]

--- a/crates/executors/src/executors/opencode.rs
+++ b/crates/executors/src/executors/opencode.rs
@@ -1753,18 +1753,8 @@ pub(super) fn build_opencode_compatible_mcp_servers(
                 server.get("type").and_then(Value::as_str),
                 Some("http" | "sse")
             );
-        let allowed = if is_remote {
-            ["type", "url", "httpUrl", "headers", "enabled", "disabled"].as_slice()
-        } else {
-            ["type", "command", "args", "env", "enabled", "disabled"].as_slice()
-        };
-        if server.keys().any(|key| !allowed.contains(&key.as_str())) {
-            return Err(ExecutorError::Configuration(format!(
-                "{adapter_name} cannot safely translate a member MCP server field"
-            )));
-        }
-
-        let mut converted = Map::new();
+        let mut converted = server.clone();
+        converted.remove("disabled");
         if is_remote {
             if !matches!(
                 server.get("type").and_then(Value::as_str),
@@ -1786,11 +1776,9 @@ pub(super) fn build_opencode_compatible_mcp_servers(
                     "{adapter_name} rejected an empty member MCP remote URL"
                 )));
             }
+            converted.remove("httpUrl");
             converted.insert("type".to_string(), Value::String("remote".to_string()));
             converted.insert("url".to_string(), url);
-            if let Some(headers) = server.get("headers") {
-                converted.insert("headers".to_string(), headers.clone());
-            }
         } else {
             if !matches!(
                 server.get("type").and_then(Value::as_str),
@@ -1811,11 +1799,13 @@ pub(super) fn build_opencode_compatible_mcp_servers(
             if let Some(args) = server.get("args").and_then(Value::as_array) {
                 command_and_args.extend(args.iter().cloned());
             }
+            converted.remove("args");
             converted.insert("type".to_string(), Value::String("local".to_string()));
             converted.insert("command".to_string(), Value::Array(command_and_args));
             if let Some(environment) = server.get("env") {
                 converted.insert("environment".to_string(), environment.clone());
             }
+            converted.remove("env");
         }
         if let Some(enabled) = effective_mcp_enabled(server) {
             converted.insert("enabled".to_string(), Value::Bool(enabled));
@@ -1988,12 +1978,16 @@ mod tests {
                 "local": {
                     "command": "/bin/echo",
                     "args": ["serve"],
-                    "env": {"TOKEN": "member-secret"}
+                    "env": {"TOKEN": "member-secret"},
+                    "cwd": ".",
+                    "startup_timeout_sec": 120,
+                    "future_option": {"nested": true}
                 },
                 "remote": {
                     "type": "sse",
                     "httpUrl": "https://example.test/events",
-                    "headers": {"Authorization": "Bearer member-secret"}
+                    "headers": {"Authorization": "Bearer member-secret"},
+                    "future_remote_option": "preserved"
                 }
             }
         }))
@@ -2017,7 +2011,20 @@ mod tests {
             config["mcp"]["local"]["environment"]["TOKEN"],
             json!("member-secret")
         );
+        assert_eq!(config["mcp"]["local"]["cwd"], json!("."));
+        assert_eq!(config["mcp"]["local"]["startup_timeout_sec"], json!(120));
+        assert_eq!(
+            config["mcp"]["local"]["future_option"],
+            json!({"nested": true})
+        );
+        assert!(config["mcp"]["local"].get("args").is_none());
+        assert!(config["mcp"]["local"].get("env").is_none());
         assert_eq!(config["mcp"]["remote"]["type"], json!("remote"));
+        assert_eq!(
+            config["mcp"]["remote"]["future_remote_option"],
+            json!("preserved")
+        );
+        assert!(config["mcp"]["remote"].get("httpUrl").is_none());
         assert_eq!(
             config["provider"]["custom"]["options"]["apiKey"],
             json!("provider-key")

--- a/crates/executors/src/mcp_config.rs
+++ b/crates/executors/src/mcp_config.rs
@@ -712,7 +712,10 @@ mod tests {
                     "command": "mcp-tool",
                     "args": ["serve"],
                     "env": {"MODE": "test"},
-                    "disabled": false
+                    "disabled": false,
+                    "cwd": ".",
+                    "startup_timeout_sec": 120,
+                    "future_option": {"nested": true}
                 },
                 "stream": {
                     "type": "sse",
@@ -731,6 +734,15 @@ mod tests {
             .map(String::as_str)
             .collect::<Vec<_>>();
         assert_eq!(server_names, vec!["alpha", "stream", "zeta"]);
+        assert_eq!(serialized["mcpServers"]["alpha"]["cwd"], ".");
+        assert_eq!(
+            serialized["mcpServers"]["alpha"]["startup_timeout_sec"],
+            120
+        );
+        assert_eq!(
+            serialized["mcpServers"]["alpha"]["future_option"],
+            serde_json::json!({"nested": true})
+        );
         assert_eq!(
             serde_json::from_value::<MemberMcpConfig>(serialized).expect("round trip config"),
             config

--- a/crates/executors/src/mcp_run.rs
+++ b/crates/executors/src/mcp_run.rs
@@ -73,20 +73,35 @@ pub struct PreparedMcpRun {
     cleanup: Option<ExecutorRunCleanup>,
 }
 
-/// Secret-safe failure metadata for the public run-scoped MCP preparation boundary.
+/// Failure metadata for the public run-scoped MCP preparation boundary.
 ///
-/// Adapter errors are deliberately classified and dropped rather than retained as a
-/// source: diagnostics may contain command arguments, headers, or environment values.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error(
-    "Run-scoped MCP preparation failed: {kind}; mcp_config_hash={config_hash}; mcp_server_count={server_count}; mcp_server_names={server_names:?}"
-)]
+/// Configuration diagnostics are preserved so users can correct the rejected
+/// configuration. Resource and adapter runtime errors remain classified because
+/// they may contain command arguments, headers, or environment values.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpRunPreparationError {
     kind: McpRunPreparationFailureKind,
     config_hash: String,
     server_count: usize,
     server_names: Vec<String>,
+    configuration_error: Option<String>,
 }
+
+impl fmt::Display for McpRunPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "Run-scoped MCP preparation failed: {}; mcp_config_hash={}; mcp_server_count={}; mcp_server_names={:?}",
+            self.kind, self.config_hash, self.server_count, self.server_names
+        )?;
+        if let Some(configuration_error) = &self.configuration_error {
+            write!(formatter, "; Configuration error: {configuration_error}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for McpRunPreparationError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum McpRunPreparationFailureKind {
@@ -111,6 +126,7 @@ impl McpRunPreparationError {
             config_hash: "unavailable".to_string(),
             server_count: 0,
             server_names: Vec::new(),
+            configuration_error: None,
         }
     }
 
@@ -122,10 +138,10 @@ impl McpRunPreparationError {
     }
 
     pub fn from_executor_error(canonical: &MemberMcpConfig, error: ExecutorError) -> Self {
-        let kind = match error {
-            ExecutorError::McpNotSupported => McpRunPreparationFailureKind::NotSupported,
+        let (kind, configuration_error) = match error {
+            ExecutorError::McpNotSupported => (McpRunPreparationFailureKind::NotSupported, None),
             ExecutorError::McpIsolationNotImplemented => {
-                McpRunPreparationFailureKind::IsolationNotImplemented
+                (McpRunPreparationFailureKind::IsolationNotImplemented, None)
             }
             ExecutorError::Io(_)
             | ExecutorError::SpawnError(_)
@@ -134,17 +150,22 @@ impl McpRunPreparationError {
             | ExecutorError::TomlDeserialize(_)
             | ExecutorError::Yaml(_)
             | ExecutorError::CommandBuild(_)
-            | ExecutorError::ExecutableNotFound { .. } => {
-                McpRunPreparationFailureKind::ResourcePreparationFailed
-            }
+            | ExecutorError::ExecutableNotFound { .. } => (
+                McpRunPreparationFailureKind::ResourcePreparationFailed,
+                None,
+            ),
             ExecutorError::FollowUpNotSupported(_)
             | ExecutorError::UnknownExecutorType(_)
             | ExecutorError::ExecutorApprovalError(_)
             | ExecutorError::SetupHelperNotSupported
-            | ExecutorError::AuthRequired(_)
-            | ExecutorError::Configuration(_) => McpRunPreparationFailureKind::AdapterRejected,
+            | ExecutorError::AuthRequired(_) => {
+                (McpRunPreparationFailureKind::AdapterRejected, None)
+            }
+            ExecutorError::Configuration(message) => {
+                (McpRunPreparationFailureKind::AdapterRejected, Some(message))
+            }
         };
-        Self::from_kind(kind, canonical)
+        Self::from_kind_and_configuration_error(kind, canonical, configuration_error)
     }
 
     pub fn kind(&self) -> McpRunPreparationFailureKind {
@@ -164,6 +185,14 @@ impl McpRunPreparationError {
     }
 
     fn from_kind(kind: McpRunPreparationFailureKind, canonical: &MemberMcpConfig) -> Self {
+        Self::from_kind_and_configuration_error(kind, canonical, None)
+    }
+
+    fn from_kind_and_configuration_error(
+        kind: McpRunPreparationFailureKind,
+        canonical: &MemberMcpConfig,
+        configuration_error: Option<String>,
+    ) -> Self {
         let server_names = canonical.mcp_servers.keys().cloned().collect::<Vec<_>>();
         Self {
             kind,
@@ -171,6 +200,7 @@ impl McpRunPreparationError {
                 .unwrap_or_else(|_| "unavailable".to_string()),
             server_count: server_names.len(),
             server_names,
+            configuration_error,
         }
     }
 }
@@ -588,6 +618,33 @@ mod tests {
             McpRunPreparationFailureKind::ResourcePreparationFailed
         );
         assert_eq!(error.server_count(), 1);
+    }
+
+    #[test]
+    fn configuration_diagnostics_are_preserved_at_the_public_preparation_boundary() {
+        let canonical = MemberMcpConfig {
+            mcp_servers: [(
+                "computer-use".to_string(),
+                json!({"command": "mcp-tool", "cwd": "."}),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        let diagnostic = "Codex rejected mcpServers.computer-use.cwd";
+
+        let error = McpRunPreparationError::from_executor_error(
+            &canonical,
+            ExecutorError::Configuration(diagnostic.to_string()),
+        );
+        let display = error.to_string();
+        let debug = format!("{error:?}");
+
+        for output in [&display, &debug] {
+            assert!(output.contains(diagnostic));
+            assert!(output.contains("computer-use"));
+        }
+        assert!(display.contains("Configuration error:"));
+        assert_eq!(error.kind(), McpRunPreparationFailureKind::AdapterRejected);
     }
 
     #[test]

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -991,7 +991,10 @@ mod tests {
                     "command": "mcp-tool",
                     "args": ["serve"],
                     "env": {"MODE": "test"},
-                    "disabled": false
+                    "disabled": false,
+                    "cwd": ".",
+                    "startup_timeout_sec": 120,
+                    "future_option": {"nested": true}
                 },
                 "stream": {
                     "type": "sse",

--- a/crates/services/src/services/member_scoped_mcp_migration.rs
+++ b/crates/services/src/services/member_scoped_mcp_migration.rs
@@ -481,7 +481,7 @@ mod tests {
                     true,
                 ),
                 format!(
-                    "[mcp_servers.server]\ncommand = \"tool\"\nargs = [\"serve\"]\n[mcp_servers.server.env]\nTOKEN = \"{fake_secret}\"\n"
+                    "[mcp_servers.server]\ncommand = \"tool\"\nargs = [\"serve\"]\ncwd = \".\"\nstartup_timeout_sec = 120\nfuture_option = \"preserved\"\n[mcp_servers.server.env]\nTOKEN = \"{fake_secret}\"\n"
                 ),
             ),
             (
@@ -503,6 +503,14 @@ mod tests {
                 .expect("canonicalize vendor config");
             assert_eq!(canonical.mcp_servers["server"]["env"]["TOKEN"], fake_secret);
             assert_eq!(canonical.mcp_servers["server"]["command"], "tool");
+            if runner == BaseCodingAgent::Codex {
+                assert_eq!(canonical.mcp_servers["server"]["cwd"], ".");
+                assert_eq!(canonical.mcp_servers["server"]["startup_timeout_sec"], 120);
+                assert_eq!(
+                    canonical.mcp_servers["server"]["future_option"],
+                    "preserved"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- restore Kimi session and tighten auth-token timeout handling
- isolate member-scoped MCP configuration for Codex and OpenCode runs

## Validation
- GitHub Actions Test workflow is being monitored.