### PR TITLE
feat(frontend): show file name first in source control file rows

### DIFF
--- a/frontend/src/components/source-control/SourceControlFileRow.tsx
+++ b/frontend/src/components/source-control/SourceControlFileRow.tsx
@@ -426,6 +426,7 @@ export const SourceControlFileRow: React.FC<SourceControlFileRowProps> = ({
   const fullPath =
     resolveLocalPathToAbsolutePath(file.path, viewModel.workspacePath) ??
     file.path;
+  const fileName = file.path.split(/[\\/]/).pop() || file.path;
 
   return (
     <div
@@ -456,10 +457,15 @@ export const SourceControlFileRow: React.FC<SourceControlFileRowProps> = ({
           )}
         >
           <SourceControlFileTypeIcon path={file.path} />
-          <span
-            className="min-w-0 flex-1 truncate font-mono text-[12px] text-[var(--ink-muted)]"
-          >
-            {file.path}
+          <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+            <span className="min-w-0 shrink truncate font-mono text-[12px] text-[var(--ink)]">
+              {fileName}
+            </span>
+            {fileName !== file.path && (
+              <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-[var(--ink-subtle)]">
+                {file.path}
+              </span>
+            )}
           </span>
         </button>
       </div>


### PR DESCRIPTION
## 变更内容

文件变更（源代码管理）列表中，文件行改为**先显示文件名**，旁边以小字（10px、muted 色）截断显示**完整路径**，tooltip 仍展示解析后的完整绝对路径。

- 当路径不含目录（文件名即路径）时不重复显示小字路径。
- 仅改动 `frontend/src/components/source-control/SourceControlFileRow.tsx`。

## 验证

- `SourceControlFileRow.test.tsx` 冒烟测试 4 项全部通过
- `pnpm lint`（tsc --noEmit）通过