### PR TITLE
feat: add GPT-6 Codex and latest Claude Code model profiles

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -49,17 +49,42 @@
       },
       "OPUS_4_6": {
         "CLAUDE_CODE": {
-          "model": "opus"
+          "model": "claude-opus-4-6"
         }
       },
       "SONNET_4_6": {
         "CLAUDE_CODE": {
-          "model": "sonnet"
+          "model": "claude-sonnet-4-6"
         }
       },
       "OPUS_4_7": {
         "CLAUDE_CODE": {
-          "model": "opus"
+          "model": "claude-opus-4-7"
+        }
+      },
+      "OPUS_4_8": {
+        "CLAUDE_CODE": {
+          "model": "claude-opus-4-8"
+        }
+      },
+      "FABLE_5_1": {
+        "CLAUDE_CODE": {
+          "model": "claude-fable-5-1"
+        }
+      },
+      "OPUS_5": {
+        "CLAUDE_CODE": {
+          "model": "claude-opus-5"
+        }
+      },
+      "SONNET_5": {
+        "CLAUDE_CODE": {
+          "model": "claude-sonnet-5"
+        }
+      },
+      "HAIKU_4_5": {
+        "CLAUDE_CODE": {
+          "model": "claude-haiku-4-5-20251001"
         }
       },
       "APPROVALS": {
@@ -127,7 +152,14 @@
     "CODEX": {
       "DEFAULT": {
         "CODEX": {
-          "model": "gpt-5.6-sol",
+          "model": "gpt-6-astra",
+          "sandbox": "danger-full-access",
+          "model_reasoning_summary": "auto"
+        }
+      },
+      "GPT_6_ASTRA": {
+        "CODEX": {
+          "model": "gpt-6-astra",
           "sandbox": "danger-full-access",
           "model_reasoning_summary": "auto"
         }

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -31,6 +31,7 @@ fn codex_model_cache_paths() -> Vec<PathBuf> {
 }
 
 const CODEX_MODEL_FALLBACKS: &[&str] = &[
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
@@ -123,6 +124,7 @@ pub enum ReasoningEffort {
     High,
     Xhigh,
     Max,
+    Ultra,
 }
 
 /// Model reasoning summary style
@@ -465,7 +467,7 @@ impl StandardCodingAgentExecutor for Codex {
 }
 
 impl Codex {
-    const BASE_COMMAND: &'static str = "npx -y @openai/codex@0.147.0";
+    const BASE_COMMAND: &'static str = "npx -y @openai/codex@0.153.4";
 
     pub fn base_command() -> &'static str {
         Self::BASE_COMMAND
@@ -991,12 +993,13 @@ mod tests {
     }
 
     #[test]
-    fn base_command_uses_codex_0_147_0() {
-        assert_eq!(Codex::base_command(), "npx -y @openai/codex@0.147.0");
+    fn base_command_uses_codex_0_153_4() {
+        assert_eq!(Codex::base_command(), "npx -y @openai/codex@0.153.4");
     }
 
     #[test]
-    fn codex_model_fallbacks_include_latest_gpt_5_6_models() {
+    fn codex_model_fallbacks_include_gpt_6_and_gpt_5_6_models() {
+        assert!(CODEX_MODEL_FALLBACKS.contains(&"gpt-6-astra"));
         assert!(CODEX_MODEL_FALLBACKS.contains(&"gpt-5.6-sol"));
         assert!(CODEX_MODEL_FALLBACKS.contains(&"gpt-5.6-terra"));
         assert!(CODEX_MODEL_FALLBACKS.contains(&"gpt-5.6-luna"));

--- a/crates/executors/src/profile.rs
+++ b/crates/executors/src/profile.rs
@@ -568,7 +568,8 @@ mod tests {
     fn default_profiles_include_supported_codex_models() {
         let profiles = ExecutorConfigs::from_defaults();
 
-        assert_codex_model(&profiles, "DEFAULT", "gpt-5.6-sol");
+        assert_codex_model(&profiles, "DEFAULT", "gpt-6-astra");
+        assert_codex_model(&profiles, "GPT_6_ASTRA", "gpt-6-astra");
         assert_codex_model(&profiles, "GPT_5.6_SOL", "gpt-5.6-sol");
         assert_codex_model(&profiles, "GPT_5.6_TERRA", "gpt-5.6-terra");
         assert_codex_model(&profiles, "GPT_5.6_LUNA", "gpt-5.6-luna");
@@ -735,9 +736,14 @@ mod tests {
         assert_claude_model(&profiles, "SONNET_1M", "sonnet[1m]");
         assert_claude_model(&profiles, "OPUS_1M", "opus[1m]");
         assert_claude_model(&profiles, "OPUSPLAN", "opusplan");
-        assert_claude_model(&profiles, "OPUS_4_6", "opus");
-        assert_claude_model(&profiles, "SONNET_4_6", "sonnet");
-        assert_claude_model(&profiles, "OPUS_4_7", "opus");
+        assert_claude_model(&profiles, "OPUS_4_6", "claude-opus-4-6");
+        assert_claude_model(&profiles, "SONNET_4_6", "claude-sonnet-4-6");
+        assert_claude_model(&profiles, "OPUS_4_7", "claude-opus-4-7");
+        assert_claude_model(&profiles, "OPUS_4_8", "claude-opus-4-8");
+        assert_claude_model(&profiles, "FABLE_5_1", "claude-fable-5-1");
+        assert_claude_model(&profiles, "OPUS_5", "claude-opus-5");
+        assert_claude_model(&profiles, "SONNET_5", "claude-sonnet-5");
+        assert_claude_model(&profiles, "HAIKU_4_5", "claude-haiku-4-5-20251001");
         assert_kimi_model(
             &profiles,
             "moonshot-cn/kimi-k2.6,thinking",

--- a/crates/server/src/routes/config/cli.rs
+++ b/crates/server/src/routes/config/cli.rs
@@ -356,7 +356,7 @@ async fn delete_custom_provider(
     // 任务7：如果删除的是当前默认 Provider，自动回退到 anthropic
     if config.provider.default == id {
         config.provider.default = "anthropic".to_string();
-        config.model.default = "claude-sonnet-4-20250514".to_string();
+        config.model.default = CliConfig::default_config().model.default;
     }
 
     if let Err(e) = write_cli_config_to_disk(&config).await {

--- a/crates/services/src/services/agent_runtime.rs
+++ b/crates/services/src/services/agent_runtime.rs
@@ -1744,7 +1744,7 @@ fn reasoning_capability_for_runner(
             options: strings(["low", "medium", "high"]),
         }),
         BaseCodingAgent::Codex => Some(AgentRuntimeReasoningCapability::Effort {
-            options: strings(["low", "medium", "high", "xhigh", "max"]),
+            options: strings(["low", "medium", "high", "xhigh", "max", "ultra"]),
         }),
         BaseCodingAgent::Droid => Some(AgentRuntimeReasoningCapability::Effort {
             options: strings(["none", "dynamic", "off", "low", "medium", "high"]),
@@ -3391,6 +3391,12 @@ mod tests {
 
     #[test]
     fn reasoning_capabilities_match_current_acp_controls() {
+        assert_eq!(
+            reasoning_capability_for_runner(BaseCodingAgent::Codex),
+            Some(AgentRuntimeReasoningCapability::Effort {
+                options: strings(["low", "medium", "high", "xhigh", "max", "ultra"]),
+            })
+        );
         assert_eq!(
             reasoning_capability_for_runner(BaseCodingAgent::QwenCode),
             Some(AgentRuntimeReasoningCapability::Effort {

--- a/crates/services/src/services/build_stats/model_pricing_sync.rs
+++ b/crates/services/src/services/build_stats/model_pricing_sync.rs
@@ -43,6 +43,7 @@ const MODEL_ID_ALIASES: &[(&str, &[&str])] = &[
     ),
     ("qwen-2.5-coder", &["qwen/qwen-2.5-coder-32b-instruct"]),
     ("gpt-5-codex", &["openai/gpt-5-codex"]),
+    ("gpt-6-astra", &["openai/gpt-6-astra"]),
     ("gpt-5.6", &["openai/gpt-5.6"]),
     ("gpt-5.6-sol", &["openai/gpt-5.6-sol"]),
     ("gpt-5.6-terra", &["openai/gpt-5.6-terra"]),
@@ -570,6 +571,7 @@ mod tests {
         assert_eq!(resolve_canonical_id("GLM-5.1"), "glm-5.1");
         assert_eq!(resolve_canonical_id("z-ai/glm-5.1"), "glm-5.1");
         assert_eq!(resolve_canonical_id("openai/gpt-5-codex"), "gpt-5-codex");
+        assert_eq!(resolve_canonical_id("openai/gpt-6-astra"), "gpt-6-astra");
         assert_eq!(resolve_canonical_id("openai/gpt-5.6-sol"), "gpt-5.6-sol");
         assert_eq!(
             resolve_canonical_id("openai/gpt-5.6-terra"),

--- a/crates/services/src/services/cli_config.rs
+++ b/crates/services/src/services/cli_config.rs
@@ -137,7 +137,7 @@ impl CliConfig {
                 custom_providers: None,
             },
             model: ModelConfig {
-                default: "claude-sonnet-4-20250514".to_string(),
+                default: "claude-sonnet-5".to_string(),
                 anthropic: None,
                 openai: None,
                 google: None,
@@ -355,5 +355,18 @@ impl OpenTeamsCliConfig {
 
     pub fn config_dir() -> Option<std::path::PathBuf> {
         dirs::home_dir().map(|h| h.join(".config").join("openteams-cli"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliConfig;
+
+    #[test]
+    fn default_config_uses_current_anthropic_model() {
+        let config = CliConfig::default_config();
+
+        assert_eq!(config.provider.default, "anthropic");
+        assert_eq!(config.model.default, "claude-sonnet-5");
     }
 }

--- a/crates/services/src/services/config/preset_loader.rs
+++ b/crates/services/src/services/config/preset_loader.rs
@@ -1464,6 +1464,23 @@ mod tests {
             );
         }
 
+        let codex_presets = presets
+            .members
+            .iter()
+            .filter(|preset| preset.runner_type.as_deref() == Some("CODEX"))
+            .collect::<Vec<_>>();
+        assert!(!codex_presets.is_empty());
+        for preset in codex_presets {
+            assert!(
+                matches!(
+                    preset.recommended_model.as_deref(),
+                    Some("gpt-6-astra" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna")
+                ),
+                "Codex preset `{}` must use a current OpenAI model",
+                preset.id
+            );
+        }
+
         let team = presets
             .teams
             .iter()

--- a/crates/services/src/services/config/presets/roles/_template.md
+++ b/crates/services/src/services/config/presets/roles/_template.md
@@ -7,8 +7,8 @@ default_workspace: workspace_path
 # Examples: CODEX, CLAUDE_CODE, GEMINI, QWEN_CODE
 runner_type: CODEX
 # Optional: preferred model under the selected executor.
-# Should match the executor profile model name, e.g. gpt-5.2-codex.
-recommended_model: gpt-5.2-codex
+# Should match the executor profile model name, e.g. gpt-6-astra.
+recommended_model: gpt-6-astra
 selected_skill_ids:
   - skill_id
 ---

--- a/crates/services/src/services/config/presets/roles/code_reviewer.md
+++ b/crates/services/src/services/config/presets/roles/code_reviewer.md
@@ -4,7 +4,7 @@ name: reviewer
 description: Review all task results and provide correction decisions.
 default_workspace: reviews
 runner_type: CODEX
-recommended_model: gpt-5.2-codex
+recommended_model: gpt-6-astra
 ---
 You are a **Reviewer** responsible for final quality control of multi-agent collaboration results.
 
@@ -47,4 +47,3 @@ Your job is not to give vague suggestions, but to make a clear review decision a
 ```
 
 Your goal is to make a clear, strict, and actionable final review decision.
-

--- a/crates/services/src/services/config/presets/roles/frontend_engineer.md
+++ b/crates/services/src/services/config/presets/roles/frontend_engineer.md
@@ -4,7 +4,7 @@ name: frontend
 description: Implement pages, components, and interactions based on UI design; connect backend APIs; handle loading states and errors.
 default_workspace: frontend
 runner_type: CODEX
-recommended_model: gpt-5.2-codex
+recommended_model: gpt-6-astra
 ---
 You are a **Frontend Engineer** responsible for page implementation and API integration.
 
@@ -36,4 +36,3 @@ Outputs should include:
 - Do not define backend fields or protocols.
 - Do not make up missing backend rules.
 - Do not change the core visual style without the design draft.
-

--- a/crates/services/src/services/config/versions/v10.rs
+++ b/crates/services/src/services/config/versions/v10.rs
@@ -535,4 +535,26 @@ mod tests {
         assert_eq!(config["theme"], "SYSTEM");
         assert_eq!(config["language"], "BROWSER");
     }
+
+    #[test]
+    fn current_config_refreshes_builtin_model_recommendations() {
+        let mut config = Config::default();
+        let builtin = config
+            .chat_presets
+            .members
+            .iter_mut()
+            .find(|preset| preset.id == "frontend_engineer")
+            .expect("frontend preset should exist");
+        builtin.recommended_model = Some("gpt-5.2-codex".to_string());
+
+        let config = config.with_completed_chat_presets();
+        let builtin = config
+            .chat_presets
+            .members
+            .iter()
+            .find(|preset| preset.id == "frontend_engineer")
+            .expect("frontend preset should exist");
+
+        assert_eq!(builtin.recommended_model.as_deref(), Some("gpt-6-astra"));
+    }
 }

--- a/crates/services/src/services/config/versions/v9.rs
+++ b/crates/services/src/services/config/versions/v9.rs
@@ -681,7 +681,7 @@ mod tests {
             .expect("frontend preset should exist");
         assert_eq!(builtin.name, "frontend");
         assert_eq!(builtin.runner_type.as_deref(), Some("CODEX"));
-        assert_eq!(builtin.recommended_model.as_deref(), Some("gpt-5.2-codex"));
+        assert_eq!(builtin.recommended_model.as_deref(), Some("gpt-6-astra"));
         assert_ne!(builtin.system_prompt, "old prompt");
     }
 

--- a/openteams-cli/packages/openteams-cli/src/plugin/codex.ts
+++ b/openteams-cli/packages/openteams-cli/src/plugin/codex.ts
@@ -18,6 +18,7 @@ const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
 const CODEX_ALLOWED_MODEL_IDS = new Set([
+  "gpt-6-astra",
   "gpt-5.6",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
@@ -35,6 +36,13 @@ const CODEX_ALLOWED_MODEL_IDS = new Set([
 ])
 
 const CODEX_FALLBACK_MODELS = [
+  {
+    id: "gpt-6-astra",
+    name: "GPT-6-Astra",
+    family: "gpt",
+    release_date: "2026-09-03",
+    cost: { input: 10, output: 50, cache: { read: 1, write: 12.5 } },
+  },
   {
     id: "gpt-5.6-sol",
     name: "GPT-5.6 Sol",

--- a/openteams-cli/packages/openteams-cli/src/provider/transform.ts
+++ b/openteams-cli/packages/openteams-cli/src/provider/transform.ts
@@ -489,6 +489,9 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
         if (id === "gpt-5-pro") return {}
         const openaiEfforts = iife(() => {
+          if (["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra"].includes(id))
+            return [...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max", "ultra"]
+          if (id === "gpt-5.6-luna") return [...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max"]
           if (id.includes("codex")) {
             if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
             return WIDELY_SUPPORTED_EFFORTS

--- a/openteams-cli/packages/openteams-cli/test/plugin/codex.test.ts
+++ b/openteams-cli/packages/openteams-cli/test/plugin/codex.test.ts
@@ -123,7 +123,7 @@ describe("plugin.codex", () => {
   })
 
   describe("applyCodexModelCatalog", () => {
-    test("keeps latest Codex models and injects missing GPT-5.6 fallbacks", () => {
+    test("keeps latest Codex models and injects missing GPT-6 and GPT-5.6 fallbacks", () => {
       const provider = {
         models: {
           "gpt-4o": { cost: { input: 1, output: 1, cache: { read: 1, write: 1 } } },
@@ -135,11 +135,20 @@ describe("plugin.codex", () => {
 
       expect(provider.models["gpt-4o"]).toBeUndefined()
       expect(provider.models["gpt-5.5"]).toBeDefined()
+      expect(provider.models["gpt-6-astra"].name).toBe("GPT-6-Astra")
+      expect(Object.keys(provider.models["gpt-6-astra"].variants)).toEqual([
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+      ])
       expect(provider.models["gpt-5.6-sol"].name).toBe("GPT-5.6 Sol")
       expect(provider.models["gpt-5.6-terra"].name).toBe("GPT-5.6 Terra")
       expect(provider.models["gpt-5.6-luna"].name).toBe("GPT-5.6 Luna")
       expect(provider.models["gpt-5.3-codex"].name).toBe("GPT-5.3 Codex")
-      expect(provider.models["gpt-5.6-sol"].cost).toEqual({
+      expect(provider.models["gpt-6-astra"].cost).toEqual({
         input: 0,
         output: 0,
         cache: { read: 0, write: 0 },

--- a/openteams-cli/packages/openteams-cli/test/provider/transform.test.ts
+++ b/openteams-cli/packages/openteams-cli/test/provider/transform.test.ts
@@ -2220,6 +2220,21 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/openai", () => {
+    test("gpt-6-astra exposes only its supported reasoning efforts", () => {
+      const model = createMockModel({
+        id: "gpt-6-astra",
+        providerID: "openai",
+        api: {
+          id: "gpt-6-astra",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-09-03",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"])
+    })
+
     test("gpt-5-pro returns empty object", () => {
       const model = createMockModel({
         id: "gpt-5-pro",

--- a/shared/schemas/codex.json
+++ b/shared/schemas/codex.json
@@ -63,6 +63,7 @@
         "high",
         "xhigh",
         "max",
+        "ultra",
         null
       ]
     },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1468,7 +1468,7 @@ export type SandboxMode = "auto" | "read-only" | "workspace-write" | "danger-ful
 
 export type AskForApproval = "unless-trusted" | "on-failure" | "on-request" | "never";
 
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 
 export type ReasoningSummary = "auto" | "concise" | "detailed" | "none";
 


### PR DESCRIPTION
## Summary
- Update Codex defaults, discovery, pricing, CLI support, and role presets for GPT-6.
- Refresh Claude Code profiles and default model configuration.
- Sync preset migrations, schemas, generated types, and CLI mapping tests.

## Validation
- Backend-reported: app-server model/list validation, 8 focused Rust tests, 130 CLI tests, frontend typecheck, and generated-type check.
- Note: the CLI workspace full typecheck has pre-existing unrelated failures.